### PR TITLE
fix cf-solace-messaging-deployment submodule remote reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cf-solace-messaging-deployment"]
 	path = cf-solace-messaging-deployment
-	url = https://github.com/SolaceDev/cf-solace-messaging-deployment/
+	url = https://github.com/SolaceLabs/cf-solace-messaging-deployment/


### PR DESCRIPTION
Fixed the submodule reference to actually point to the public submodule.